### PR TITLE
Fixes #49 Classes and properties (attributes) are not linked in a loaded model Rename 'properties' to 'attributes' in the model

### DIFF
--- a/src/lib/famix/src/model/famix/class.ts
+++ b/src/lib/famix/src/model/famix/class.ts
@@ -78,7 +78,7 @@ export class Class extends Type {
   public addPropertiesToExporter(exporter: FamixJSONExporter): void {
     super.addPropertiesToExporter(exporter);
     exporter.addProperty("isAbstract", this.getIsAbstract());
-    exporter.addProperty("properties", this.getProperties());
+    exporter.addProperty("attributes", this.getProperties()); // Moose (10) codes them as attributes
     exporter.addProperty("methods", this.getMethods());
     exporter.addProperty("superInheritances", this.getSuperInheritances());
     exporter.addProperty("subInheritances", this.getSubInheritances());  

--- a/test/access.test.ts
+++ b/test/access.test.ts
@@ -32,13 +32,13 @@ describe('Accesses', () => {
         const expectedAttributeNames: Array<string> = ['privateAttribute', 'publicAttribute'];
         const expectedMethodNames: Array<string> = ['privateMethod', 'returnAccessName'];
         testAccessCls = parsedModel.filter(el => (el.FM3 === "FamixTypeScript.Class" && el.name === "AccessClassForTesting"))[0];
-        expect(testAccessCls.properties.length).toBe(expectedAttributeNames.length);
+        expect(testAccessCls.attributes.length).toBe(expectedAttributeNames.length);
         expect(testAccessCls.methods.length).toBe(expectedMethodNames.length);
         accessClsMethods = parsedModel.filter(e => testAccessCls.methods.some(m => m.ref === e.id));
         expect(accessClsMethods.length).toBeGreaterThan(0);
         const checkMethodName = accessClsMethods.every(m => expectedMethodNames.includes(m.name));
         expect(checkMethodName).toBe(true);
-        accessClsAttributes = parsedModel.filter(e => testAccessCls.properties.some(a => a.ref === e.id));
+        accessClsAttributes = parsedModel.filter(e => testAccessCls.attributes.some(a => a.ref === e.id));
         expect(accessClsAttributes.length).toBeGreaterThan(0);
         const checkAttributeName = accessClsAttributes.every(a => expectedAttributeNames.includes(a.name));
         expect(checkAttributeName).toBe(true);


### PR DESCRIPTION
Classes and properties (attributes) are not linked in a loaded model Rename 'properties' to 'attributes' in the model